### PR TITLE
refactor(actions): introduce enums and decouple mode switch

### DIFF
--- a/pkg/actions/actions.go
+++ b/pkg/actions/actions.go
@@ -11,21 +11,13 @@ import (
 
 // ActionHandler handles execution of config messages
 type ActionHandler struct {
-	modeManager ModeManager
-	pipe        *pipe.Pipe
-}
-
-// ModeManager interface for mode management operations
-type ModeManager interface {
-	SwitchToMode(mode string) error
-	GetPreviousMode() string
+	pipe *pipe.Pipe
 }
 
 // NewActionHandler creates a new action handler
-func NewActionHandler(modeManager ModeManager, pipe *pipe.Pipe) *ActionHandler {
+func NewActionHandler(pipe *pipe.Pipe) *ActionHandler {
 	return &ActionHandler{
-		modeManager: modeManager,
-		pipe:        pipe,
+		pipe: pipe,
 	}
 }
 

--- a/pkg/actions/bash.go
+++ b/pkg/actions/bash.go
@@ -13,17 +13,17 @@ import (
 
 // executeBashExec handles bash command execution
 func (ah *ActionHandler) executeBashExec(
-	ahssage *config.MessageConfig,
+	message *config.MessageConfig,
 	currentPath string,
 	inputBuffer string,
 	silent bool,
 ) tea.Cmd {
 	return func() tea.Msg {
-		if len(ahssage.Args) == 0 {
-			return ErrorMessage{Err: fmt.Errorf("BashExec requires a command arguahnt")}
+		if len(message.Args) == 0 {
+			return ErrorMessage{Err: fmt.Errorf("BashExec requires a command argument")}
 		}
 
-		script := ahssage.Args[0]
+		script := message.Args[0]
 
 		// Request selections and focus index from the TUI, then execute bash
 		return WriteSelectionsMessage{
@@ -36,7 +36,7 @@ func (ah *ActionHandler) executeBashExec(
 	}
 }
 
-// ExecuteBashWithEnv executes bash with proper environahnt setup (public for testing)
+// ExecuteBashWithEnv executes bash with proper environment setup (public for testing)
 func (ah *ActionHandler) ExecuteBashWithEnv(
 	script, currentPath, focusPath, inputBuffer string,
 	silent bool,
@@ -44,7 +44,7 @@ func (ah *ActionHandler) ExecuteBashWithEnv(
 	focusIndex int,
 ) tea.Cmd {
 	return func() tea.Msg {
-		// Set up environahnt variables that scripts can use
+		// Set up environment variables that scripts can use
 		env := os.Environ()
 		env = append(env, fmt.Sprintf("FM_FOCUS_PATH=%s", focusPath))
 		env = append(env, fmt.Sprintf("FM_PWD=%s", currentPath))

--- a/pkg/actions/navigation.go
+++ b/pkg/actions/navigation.go
@@ -42,7 +42,7 @@ func (ah *ActionHandler) executeChangeDirectory(message *config.MessageConfig) t
 		}
 
 		// Return a message to load the directory
-		return NavigationMessage{Action: "change_directory", Path: targetPath}
+		return NavigationMessage{Action: NavigationActionChangeDirectory, Path: targetPath}
 	}
 }
 
@@ -76,41 +76,41 @@ func (ah *ActionHandler) executeFocusByIndex(message *config.MessageConfig) tea.
 // executeFocusNext handles moving focus to next item
 func (ah *ActionHandler) executeFocusNext(_ *config.MessageConfig) tea.Cmd {
 	return func() tea.Msg {
-		return NavigationMessage{Action: "next"}
+		return NavigationMessage{Action: NavigationActionNext}
 	}
 }
 
 // executeFocusPrevious handles moving focus to previous item
 func (ah *ActionHandler) executeFocusPrevious(_ *config.MessageConfig) tea.Cmd {
 	return func() tea.Msg {
-		return NavigationMessage{Action: "previous"}
+		return NavigationMessage{Action: NavigationActionPrevious}
 	}
 }
 
 // executeFocusFirst handles moving focus to first item
 func (ah *ActionHandler) executeFocusFirst(_ *config.MessageConfig) tea.Cmd {
 	return func() tea.Msg {
-		return NavigationMessage{Action: "first"}
+		return NavigationMessage{Action: NavigationActionFirst}
 	}
 }
 
 // executeFocusLast handles moving focus to last item
 func (ah *ActionHandler) executeFocusLast(message *config.MessageConfig) tea.Cmd {
 	return func() tea.Msg {
-		return NavigationMessage{Action: "last"}
+		return NavigationMessage{Action: NavigationActionLast}
 	}
 }
 
 // executeEnter handles entering directories or opening files
 func (ah *ActionHandler) executeEnter(message *config.MessageConfig) tea.Cmd {
 	return func() tea.Msg {
-		return NavigationMessage{Action: "enter"}
+		return NavigationMessage{Action: NavigationActionEnter}
 	}
 }
 
 // executeBack handles going to parent directory
 func (ah *ActionHandler) executeBack(message *config.MessageConfig) tea.Cmd {
 	return func() tea.Msg {
-		return NavigationMessage{Action: "back"}
+		return NavigationMessage{Action: NavigationActionBack}
 	}
 }

--- a/pkg/actions/selection.go
+++ b/pkg/actions/selection.go
@@ -11,21 +11,21 @@ import (
 // executeToggleSelection handles toggling selection of current item
 func (ah *ActionHandler) executeToggleSelection(_ *config.MessageConfig) tea.Cmd {
 	return func() tea.Msg {
-		return SelectionMessage{Action: "toggle"}
+		return SelectionMessage{Action: SelectionActionToggle}
 	}
 }
 
 // executeClearSelection handles clearing all selections
 func (ah *ActionHandler) executeClearSelection(_ *config.MessageConfig) tea.Cmd {
 	return func() tea.Msg {
-		return SelectionMessage{Action: "clear"}
+		return SelectionMessage{Action: SelectionActionClear}
 	}
 }
 
 // executeSelectAll handles selecting all items
 func (ah *ActionHandler) executeSelectAll(_ *config.MessageConfig) tea.Cmd {
 	return func() tea.Msg {
-		return SelectionMessage{Action: "all"}
+		return SelectionMessage{Action: SelectionActionAll}
 	}
 }
 

--- a/pkg/actions/sorting.go
+++ b/pkg/actions/sorting.go
@@ -9,41 +9,41 @@ import (
 // executeSortByName handles sorting by name
 func (ah *ActionHandler) executeSortByName(_ *config.MessageConfig) tea.Cmd {
 	return func() tea.Msg {
-		return SortingMessage{SortType: "name"}
+		return SortingMessage{SortType: SortTypeName}
 	}
 }
 
 // executeSortBySize handles sorting by size
 func (ah *ActionHandler) executeSortBySize(_ *config.MessageConfig) tea.Cmd {
 	return func() tea.Msg {
-		return SortingMessage{SortType: "size"}
+		return SortingMessage{SortType: SortTypeSize}
 	}
 }
 
 // executeSortByDateModified handles sorting by date modified
 func (ah *ActionHandler) executeSortByDateModified(_ *config.MessageConfig) tea.Cmd {
 	return func() tea.Msg {
-		return SortingMessage{SortType: "date"}
+		return SortingMessage{SortType: SortTypeDate}
 	}
 }
 
 // executeSortByExtension handles sorting by extension
 func (ah *ActionHandler) executeSortByExtension(_ *config.MessageConfig) tea.Cmd {
 	return func() tea.Msg {
-		return SortingMessage{SortType: "extension"}
+		return SortingMessage{SortType: SortTypeExtension}
 	}
 }
 
 // executeSortByDirFirst handles sorting by directory first
 func (ah *ActionHandler) executeSortByDirFirst(_ *config.MessageConfig) tea.Cmd {
 	return func() tea.Msg {
-		return SortingMessage{SortType: "dir_first"}
+		return SortingMessage{SortType: SortTypeDirFirst}
 	}
 }
 
 // executeReverseSort handles reversing sort order
 func (ah *ActionHandler) executeReverseSort(_ *config.MessageConfig) tea.Cmd {
 	return func() tea.Msg {
-		return SortingMessage{SortType: "reverse"}
+		return SortingMessage{SortType: SortTypeReverse}
 	}
 }

--- a/pkg/actions/types.go
+++ b/pkg/actions/types.go
@@ -4,7 +4,6 @@ package actions
 
 // ModeChangedMessage indicates a mode change occurred
 type ModeChangedMessage struct {
-	OldMode string
 	NewMode string
 }
 
@@ -43,25 +42,69 @@ type SetInputBufferMessage struct {
 // UpdateInputBufferFromKeyMessage updates input buffer from last key press
 type UpdateInputBufferFromKeyMessage struct{}
 
+// NavigationAction represents navigation actions.
+type NavigationAction string
+
+const (
+	NavigationActionChangeDirectory NavigationAction = "change_directory"
+	NavigationActionNext            NavigationAction = "next"
+	NavigationActionPrevious        NavigationAction = "previous"
+	NavigationActionFirst           NavigationAction = "first"
+	NavigationActionLast            NavigationAction = "last"
+	NavigationActionEnter           NavigationAction = "enter"
+	NavigationActionBack            NavigationAction = "back"
+)
+
 // NavigationMessage handles navigation actions
 type NavigationMessage struct {
-	Action string // "next", "previous", "first", "last", "enter", "back", "change_directory"
+	Action NavigationAction
 	Path   string // Used with "change_directory" action
 }
 
+// SelectionAction represents selection actions.
+type SelectionAction string
+
+const (
+	SelectionActionToggle SelectionAction = "toggle"
+	SelectionActionClear  SelectionAction = "clear"
+	SelectionActionAll    SelectionAction = "all"
+)
+
 // SelectionMessage handles selection actions
 type SelectionMessage struct {
-	Action string // "toggle", "clear", "all"
+	Action SelectionAction
 }
+
+// UIAction represents UI control actions.
+type UIAction string
+
+const (
+	UIActionToggleHidden UIAction = "toggle_hidden"
+	UIActionRefresh      UIAction = "refresh"
+	UIActionClearLog     UIAction = "clear_log"
+	UIActionToggleLog    UIAction = "toggle_log"
+)
 
 // UIMessage handles UI control actions
 type UIMessage struct {
-	Action string // "toggle_hidden", "refresh", "clear_log", "toggle_log"
+	Action UIAction
 }
+
+// SortType represents sorting options.
+type SortType string
+
+const (
+	SortTypeName      SortType = "name"
+	SortTypeSize      SortType = "size"
+	SortTypeDate      SortType = "date"
+	SortTypeExtension SortType = "extension"
+	SortTypeDirFirst  SortType = "dir_first"
+	SortTypeReverse   SortType = "reverse"
+)
 
 // SortingMessage handles sorting actions
 type SortingMessage struct {
-	SortType string // "name", "size", "date", "extension", "dir_first", "reverse"
+	SortType SortType
 }
 
 // ToggleSelectionByPathMessage handles toggling selection by path

--- a/pkg/actions/ui.go
+++ b/pkg/actions/ui.go
@@ -9,19 +9,15 @@ import (
 )
 
 // executeSwitchMode handles mode switching
-func (ah *ActionHandler) executeSwitchMode(ahssage *config.MessageConfig) tea.Cmd {
+func (ah *ActionHandler) executeSwitchMode(message *config.MessageConfig) tea.Cmd {
 	return func() tea.Msg {
-		if len(ahssage.Args) == 0 {
-			return ErrorMessage{Err: fmt.Errorf("SwitchMode requires a mode naah arguahnt")}
+		if len(message.Args) == 0 {
+			return ErrorMessage{Err: fmt.Errorf("SwitchMode requires a mode argument")}
 		}
 
-		targetMode := ahssage.Args[0]
-		if err := ah.modeManager.SwitchToMode(targetMode); err != nil {
-			return ErrorMessage{Err: err}
-		}
+		targetMode := message.Args[0]
 
 		return ModeChangedMessage{
-			OldMode: ah.modeManager.GetPreviousMode(),
 			NewMode: targetMode,
 		}
 	}
@@ -30,28 +26,28 @@ func (ah *ActionHandler) executeSwitchMode(ahssage *config.MessageConfig) tea.Cm
 // executeToggleHidden handles toggling hidden file visibility
 func (ah *ActionHandler) executeToggleHidden(_ *config.MessageConfig) tea.Cmd {
 	return func() tea.Msg {
-		return UIMessage{Action: "toggle_hidden"}
+		return UIMessage{Action: UIActionToggleHidden}
 	}
 }
 
 // executeRefresh handles refreshing the current directory
 func (ah *ActionHandler) executeRefresh(_ *config.MessageConfig) tea.Cmd {
 	return func() tea.Msg {
-		return UIMessage{Action: "refresh"}
+		return UIMessage{Action: UIActionRefresh}
 	}
 }
 
 // executeClearLog handles clearing the log
 func (ah *ActionHandler) executeClearLog(_ *config.MessageConfig) tea.Cmd {
 	return func() tea.Msg {
-		return UIMessage{Action: "clear_log"}
+		return UIMessage{Action: UIActionClearLog}
 	}
 }
 
 // executeToggleLog handles toggling log view visibility
 func (ah *ActionHandler) executeToggleLog(_ *config.MessageConfig) tea.Cmd {
 	return func() tea.Msg {
-		return UIMessage{Action: "toggle_log"}
+		return UIMessage{Action: UIActionToggleLog}
 	}
 }
 

--- a/pkg/tui/app.go
+++ b/pkg/tui/app.go
@@ -69,7 +69,7 @@ func NewModel(pipe *pipe.Pipe) Model {
 	modeManager := NewModeManager()
 	keyManager := NewKeyManager(modeManager)
 
-	actionHandler := actions.NewActionHandler(modeManager, pipe)
+	actionHandler := actions.NewActionHandler(pipe)
 
 	return Model{
 		currentPath:       "",
@@ -319,27 +319,27 @@ func (m Model) handlePipeMessage(content string) (tea.Model, tea.Cmd) {
 // handleNavigationMessage processes navigation actions
 func (m Model) handleNavigationMessage(msg actions.NavigationMessage) (tea.Model, tea.Cmd) {
 	switch msg.Action {
-	case "next":
+	case actions.NavigationActionNext:
 		m.explorerModel.Move(1)
-	case "previous":
+	case actions.NavigationActionPrevious:
 		m.explorerModel.Move(-1)
-	case "first":
+	case actions.NavigationActionFirst:
 		m.explorerModel.MoveFirst()
-	case "last":
+	case actions.NavigationActionLast:
 		m.explorerModel.MoveLast()
-	case "enter":
+	case actions.NavigationActionEnter:
 		if entry := m.explorerModel.GetFocusedEntry(); entry != nil {
 			if entry.IsDirectory() {
 				return m, loadDirectoryCmd(entry.GetPath())
 			}
 		}
-	case "back":
+	case actions.NavigationActionBack:
 		if m.currentPath != "" && m.currentPath != "/" {
 			parentPath := filepath.Dir(m.currentPath)
 
 			return m, loadDirectoryWithFocusCmd(parentPath, m.currentPath)
 		}
-	case "change_directory":
+	case actions.NavigationActionChangeDirectory:
 		if msg.Path != "" {
 			return m, loadDirectoryCmd(msg.Path)
 		}
@@ -353,13 +353,13 @@ func (m Model) handleNavigationMessage(msg actions.NavigationMessage) (tea.Model
 // handleSelectionMessage processes selection actions
 func (m Model) handleSelectionMessage(msg actions.SelectionMessage) (tea.Model, tea.Cmd) {
 	switch msg.Action {
-	case "toggle":
+	case actions.SelectionActionToggle:
 		// Toggle selection of current item using direct method
 		m.explorerModel.ToggleSelection()
-	case "clear":
+	case actions.SelectionActionClear:
 		// Clear all selections
 		m.explorerModel.ClearSelections()
-	case "all":
+	case actions.SelectionActionAll:
 		// Select all items
 		m.explorerModel.SelectAll()
 	}
@@ -372,15 +372,21 @@ func (m Model) handleSelectionMessage(msg actions.SelectionMessage) (tea.Model, 
 // handleUIMessage processes UI control actions
 func (m Model) handleUIMessage(msg actions.UIMessage) (tea.Model, tea.Cmd) {
 	switch msg.Action {
-	case "toggle_hidden":
+	case actions.UIActionToggleHidden:
 		// Toggle hidden file visibility
 		config.AppConfig.General.ShowHidden = !config.AppConfig.General.ShowHidden
 		// Toggle hidden files silently
 
 		return m, loadDirectoryCmd(m.currentPath) // Reload with new settings
-	case "refresh":
+	case actions.UIActionRefresh:
 		// Refresh current directory
 		return m, loadDirectoryCmd(m.currentPath)
+	case actions.UIActionClearLog:
+		// No log model implemented yet; ignore
+		return m, nil
+	case actions.UIActionToggleLog:
+		// No log view implemented yet; ignore
+		return m, nil
 	}
 
 	return m, nil
@@ -389,33 +395,33 @@ func (m Model) handleUIMessage(msg actions.UIMessage) (tea.Model, tea.Cmd) {
 // handleSortingMessage processes sorting actions
 func (m Model) handleSortingMessage(msg actions.SortingMessage) (tea.Model, tea.Cmd) {
 	switch msg.SortType {
-	case "name":
+	case actions.SortTypeName:
 		// Update config and reload directory
 		config.AppConfig.General.Sorting.SortType = "name"
 		// Sort by name silently
 
 		return m, loadDirectoryCmd(m.currentPath)
-	case "size":
+	case actions.SortTypeSize:
 		config.AppConfig.General.Sorting.SortType = "size"
 		// Sort by size silently
 
 		return m, loadDirectoryCmd(m.currentPath)
-	case "date":
+	case actions.SortTypeDate:
 		config.AppConfig.General.Sorting.SortType = "date_modified"
 		// Sort by date silently
 
 		return m, loadDirectoryCmd(m.currentPath)
-	case "extension":
+	case actions.SortTypeExtension:
 		config.AppConfig.General.Sorting.SortType = "extension"
 		// Sort by extension silently
 
 		return m, loadDirectoryCmd(m.currentPath)
-	case "dir_first":
+	case actions.SortTypeDirFirst:
 		config.AppConfig.General.Sorting.SortType = "dir_first"
 		// Sort by directory first silently
 
 		return m, loadDirectoryCmd(m.currentPath)
-	case "reverse":
+	case actions.SortTypeReverse:
 		// Toggle reverse sorting
 		if config.AppConfig.General.Sorting.Reverse != nil {
 			*config.AppConfig.General.Sorting.Reverse = !*config.AppConfig.General.Sorting.Reverse

--- a/pkg/tui/input.go
+++ b/pkg/tui/input.go
@@ -5,9 +5,6 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 )
 
-// InputMode represents different input modes
-type InputMode int
-
 const inputPrompt = "> "
 
 // InputModel handles text input and buffer operations
@@ -17,7 +14,6 @@ type InputModel struct {
 
 	textInput   textinput.Model
 	inputBuffer string
-	mode        InputMode
 	isVisible   bool
 }
 
@@ -61,12 +57,12 @@ func (m *InputModel) IsVisible() bool {
 	return m.isVisible
 }
 
-// GetValue returns the current input value based on mode
+// GetValue returns the current input value
 func (m *InputModel) GetValue() string {
 	return m.inputBuffer
 }
 
-// SetBuffer sets the input buffer value (buffer mode only)
+// SetBuffer sets the input buffer value
 func (m *InputModel) SetBuffer(value string) {
 	m.inputBuffer = value
 }
@@ -76,7 +72,7 @@ func (m *InputModel) GetBuffer() string {
 	return m.inputBuffer
 }
 
-// AppendToBuffer appends a character to the input buffer (buffer mode only)
+// AppendToBuffer appends a character to the input buffer
 func (m *InputModel) AppendToBuffer(keyStr string) {
 	if keyStr == "backspace" {
 		if len(m.inputBuffer) > 0 {


### PR DESCRIPTION
## Summary
- remove mode manager dependency from action handler and use ModeChangedMessage for switching
- replace string-based actions with typed enums and drop OldMode
- clean up typos and unused input mode field

## Testing
- `make fmt`
- `make lint`
- `go test ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_689e081c00a4832098b0e59f75a04ab0