### PR TITLE
refactor: streamline bash execution in TUI

### DIFF
--- a/pkg/actions/actions.go
+++ b/pkg/actions/actions.go
@@ -28,10 +28,9 @@ func (ah *ActionHandler) wrapSimple(handler func(*config.MessageConfig) tea.Cmd)
 // wrapBashExec creates a wrapper function for bash execution with specific silent flag
 func (ah *ActionHandler) wrapBashExec(silent bool) ActionHandlerFunc {
 	return func(message *config.MessageConfig, currentPath string, inputBuffer string) tea.Cmd {
-		return ah.executeBashExec(message, currentPath, inputBuffer, silent)
+		return ah.executeBashExec(message, silent)
 	}
 }
-
 
 // NewActionHandler creates a new action handler
 func NewActionHandler(pipe *pipe.Pipe) *ActionHandler {

--- a/pkg/actions/bash.go
+++ b/pkg/actions/bash.go
@@ -1,11 +1,6 @@
 package actions
 
 import (
-	"fmt"
-	"os"
-	"os/exec"
-	"strings"
-
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/dinhhuy258/fm/pkg/config"
@@ -14,165 +9,14 @@ import (
 // executeBashExec handles bash command execution
 func (ah *ActionHandler) executeBashExec(
 	message *config.MessageConfig,
-	currentPath string,
-	inputBuffer string,
 	silent bool,
 ) tea.Cmd {
 	return func() tea.Msg {
 		script := message.Args[0]
-
-		return WriteSelectionsMessage{
-			Script:        script,
-			CurrentPath:   currentPath,
-			InputBuffer:   inputBuffer,
-			Silent:        silent,
-			SelectionPath: "",
-		}
-	}
-}
-
-// ExecuteBashWithEnv executes bash with proper environment setup (public for testing)
-func (ah *ActionHandler) ExecuteBashWithEnv(
-	script, currentPath, focusPath, inputBuffer string,
-	silent bool,
-	selections []string,
-	focusIndex int,
-) tea.Cmd {
-	return func() tea.Msg {
-		// Set up environment variables that scripts can use
-		env := os.Environ()
-		env = append(env, fmt.Sprintf("FM_FOCUS_PATH=%s", focusPath))
-		env = append(env, fmt.Sprintf("FM_PWD=%s", currentPath))
-		env = append(env, fmt.Sprintf("FM_FOCUS_IDX=%d", focusIndex))
-
-		// Add input buffer
-		env = append(env, fmt.Sprintf("FM_INPUT_BUFFER=%s", inputBuffer))
-
-		if ah.pipe != nil {
-			// Write selections to pipe file before execution (like GoCUI)
-			if len(selections) > 0 {
-				selectionPath := ah.pipe.GetSelectionPath()
-				if err := writeSelectionsToFile(selectionPath, selections); err != nil {
-					return ErrorMessage{Err: fmt.Errorf("failed to write selections to pipe: %w", err)}
-				}
-			}
-
-			env = append(env, fmt.Sprintf("FM_PIPE_MSG_IN=%s", ah.pipe.GetMessageInPath()))
-			env = append(env, fmt.Sprintf("FM_PIPE_SELECTION=%s", ah.pipe.GetSelectionPath()))
-			env = append(env, fmt.Sprintf("FM_SESSION_PATH=%s", ah.pipe.GetSessionPath()))
-		}
-
-		// Execute the bash script
-		cmd := exec.Command("bash", "-c", script)
-		cmd.Env = env
-		cmd.Dir = currentPath
-
 		if silent {
-			// For silent execution, run in background
-			err := cmd.Start()
-			if err != nil {
-				return ErrorMessage{Err: fmt.Errorf("failed to start bash command: %w", err)}
-			}
-
-			// Don't wait for completion for silent commands, but clean up properly
-			go func() {
-				// Clean up the background process
-				_ = cmd.Wait()
-			}()
-
-			return nil
-		} else {
-			// Check if this is an interactive command (contains stdin/stdout interaction keywords)
-			if isInteractiveCommand(script) {
-				// For interactive commands, we need to suspend the TUI
-				return InteractiveBashMessage{
-					Script:      script,
-					Environment: env,
-					WorkingDir:  currentPath,
-				}
-			} else {
-				// For non-interactive execution, capture output
-				output, err := cmd.CombinedOutput()
-				if err != nil {
-					return ErrorMessage{Err: fmt.Errorf("bash command failed: %w", err)}
-				}
-
-				return BashOutputMessage{
-					Output: string(output),
-					Silent: false,
-				}
-			}
+			return BashExecSilentlyMessage{Script: script}
 		}
+
+		return BashExecMessage{Script: script}
 	}
-}
-
-// writeSelectionsToFile writes selected file paths to the selection pipe file
-func writeSelectionsToFile(path string, selections []string) error {
-	// Use more appropriate permissions for temporary files (owner read/write only)
-	const perm = 0600
-
-	if len(selections) == 0 {
-		// Write empty file if no selections
-		return os.WriteFile(path, []byte(""), perm)
-	}
-
-	content := strings.Join(selections, "\n") + "\n"
-
-	return os.WriteFile(path, []byte(content), perm)
-}
-
-// isInteractiveCommand determines if a command is likely to be interactive
-func isInteractiveCommand(script string) bool {
-	// Check for common interactive commands and patterns
-	// Use word boundaries to avoid false positives
-	interactiveCommands := []string{
-		"vim", "nvim", "nano", "emacs", "vi",
-		"less", "more", "man", "pager",
-		"sudo", "ssh", "ftp", "telnet",
-		"top", "htop", "watch",
-		"git commit", "git add -p", "git rebase -i",
-		"fzf", "sk", "selecta",
-	}
-
-	scriptLower := strings.ToLower(strings.TrimSpace(script))
-
-	// Check for commands at word boundaries to avoid false positives
-	for _, cmd := range interactiveCommands {
-		if strings.HasPrefix(scriptLower, cmd+" ") || scriptLower == cmd {
-			// Special case: git commit with -m flag is not interactive
-			if cmd == "git commit" &&
-				(strings.Contains(scriptLower, " -m ") || strings.Contains(scriptLower, " --message")) {
-				continue
-			}
-
-			return true
-		}
-	}
-
-	// Check for interactive flags and patterns
-	interactivePatterns := []string{
-		"python -i", "python3 -i",
-		"bash -i", "sh -i",
-		"read ", "select ",
-		"$EDITOR", "${EDITOR}",
-	}
-
-	for _, pattern := range interactivePatterns {
-		if strings.Contains(scriptLower, pattern) {
-			return true
-		}
-	}
-
-	// Check for pipes to interactive commands
-	if strings.Contains(script, "|") {
-		parts := strings.Split(script, "|")
-		for _, part := range parts {
-			part = strings.TrimSpace(part)
-			if isInteractiveCommand(part) {
-				return true
-			}
-		}
-	}
-
-	return false
 }

--- a/pkg/actions/types.go
+++ b/pkg/actions/types.go
@@ -127,18 +127,12 @@ type ToggleSelectionByPathMessage struct {
 	Path string
 }
 
-// WriteSelectionsMessage requests writing selections to pipe before bash execution
-type WriteSelectionsMessage struct {
-	Script        string
-	CurrentPath   string
-	InputBuffer   string
-	Silent        bool
-	SelectionPath string
+// BashExecMessage triggers bash command execution
+type BashExecMessage struct {
+	Script string
 }
 
-// InteractiveBashMessage handles interactive bash execution with TUI suspension
-type InteractiveBashMessage struct {
-	Script      string
-	Environment []string
-	WorkingDir  string
+// BashExecSilentlyMessage triggers bash command execution silently
+type BashExecSilentlyMessage struct {
+	Script string
 }


### PR DESCRIPTION
## Summary
- handle Bash execution directly in `app.go`
- replace custom message types with `BashExecMessage` and `BashExecSilentlyMessage`

## Testing
- `make fmt`
- `go build ./...`
- `go test ./...`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_689ecd4dd7148320a1ddf410145aaa5d